### PR TITLE
Remove Compass + Ruby dependecies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "tether-drop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/HubSpot/drop",
   "authors": [
     "Adam Schwartz <adam.flynn.schwartz@gmail.com>",
@@ -25,6 +25,6 @@
     "tests"
   ],
   "dependencies": {
-    "tether": "~0.7.1"
+    "tether": "~0.7.2"
   }
 }

--- a/dist/css/drop-theme-arrows-bounce-dark.css
+++ b/dist/css/drop-theme-arrows-bounce-dark.css
@@ -1,6 +1,4 @@
 .drop-element, .drop-element:after, .drop-element:before, .drop-element *, .drop-element *:after, .drop-element *:before {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box; }
 
 .drop-element {
@@ -13,8 +11,6 @@
   max-width: 100%;
   max-height: 100%; }
   .drop-element.drop-theme-arrows-bounce-dark .drop-content {
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
     border-radius: 5px;
     position: relative;
     font-family: inherit;
@@ -110,96 +106,72 @@
       border-right-color: #000; }
 
 .drop-element.drop-theme-arrows-bounce-dark {
-  -moz-transform: translateZ(0);
-  -ms-transform: translateZ(0);
   -webkit-transform: translateZ(0);
-  transform: translateZ(0);
-  -moz-transition: opacity 0.1s;
-  -o-transition: opacity 0.1s;
-  -webkit-transition: opacity 0.1s;
-  transition: opacity 0.1s;
+          transform: translateZ(0);
+  -webkit-transition: opacity 100ms;
+          transition: opacity 100ms;
   opacity: 0; }
   .drop-element.drop-theme-arrows-bounce-dark .drop-content {
-    -moz-transition: -moz-transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
-    -o-transition: -o-transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
     -webkit-transition: -webkit-transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
-    transition: transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
-    -moz-transform: scale(0) translateZ(0);
-    -ms-transform: scale(0) translateZ(0);
+            transition: transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
     -webkit-transform: scale(0) translateZ(0);
-    transform: scale(0) translateZ(0); }
+            transform: scale(0) translateZ(0); }
   .drop-element.drop-theme-arrows-bounce-dark.drop-open {
     display: none; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-open-transitionend {
     display: block; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-after-open {
-    -moz-transition: none;
-    -o-transition: none;
     -webkit-transition: none;
-    transition: none;
+            transition: none;
     opacity: 1; }
     .drop-element.drop-theme-arrows-bounce-dark.drop-after-open .drop-content {
-      -moz-transform: scale(1) translateZ(0);
-      -ms-transform: scale(1) translateZ(0);
       -webkit-transform: scale(1) translateZ(0);
-      transform: scale(1) translateZ(0); }
+              transform: scale(1) translateZ(0); }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-bottom.drop-element-attached-center .drop-content {
-    -moz-transform-origin: 50% calc(100% + 12px);
-    -ms-transform-origin: 50% calc(100% + 12px);
-    -webkit-transform-origin: 50% calc(100% + 12px);
-    transform-origin: 50% calc(100% + 12px); }
+    -webkit-transform-origin: 50%, calc(100% + 12px);
+        -ms-transform-origin: 50%, calc(100% + 12px);
+            transform-origin: 50%, calc(100% + 12px); }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-top.drop-element-attached-center .drop-content {
-    -moz-transform-origin: 50% -12px;
-    -ms-transform-origin: 50% -12px;
-    -webkit-transform-origin: 50% -12px;
-    transform-origin: 50% -12px; }
+    -webkit-transform-origin: 50%, -12px;
+        -ms-transform-origin: 50%, -12px;
+            transform-origin: 50%, -12px; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-right.drop-element-attached-middle .drop-content {
-    -moz-transform-origin: calc(100% + 12px) 50%;
-    -ms-transform-origin: calc(100% + 12px) 50%;
-    -webkit-transform-origin: calc(100% + 12px) 50%;
-    transform-origin: calc(100% + 12px) 50%; }
+    -webkit-transform-origin: calc(100% + 12px), 50%;
+        -ms-transform-origin: calc(100% + 12px), 50%;
+            transform-origin: calc(100% + 12px), 50%; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-left.drop-element-attached-middle .drop-content {
-    -moz-transform-origin: -12px 50%;
-    -ms-transform-origin: -12px 50%;
-    -webkit-transform-origin: -12px 50%;
-    transform-origin: -12px 50%; }
+    -webkit-transform-origin: -12px, 50%;
+        -ms-transform-origin: -12px, 50%;
+            transform-origin: -12px, 50%; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-top.drop-element-attached-left.drop-target-attached-bottom .drop-content {
-    -moz-transform-origin: 0 -12px;
-    -ms-transform-origin: 0 -12px;
-    -webkit-transform-origin: 0 -12px;
-    transform-origin: 0 -12px; }
+    -webkit-transform-origin: 0, -12px;
+        -ms-transform-origin: 0, -12px;
+            transform-origin: 0, -12px; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-top.drop-element-attached-right.drop-target-attached-bottom .drop-content {
-    -moz-transform-origin: 100% -12px;
-    -ms-transform-origin: 100% -12px;
-    -webkit-transform-origin: 100% -12px;
-    transform-origin: 100% -12px; }
+    -webkit-transform-origin: 100%, -12px;
+        -ms-transform-origin: 100%, -12px;
+            transform-origin: 100%, -12px; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-bottom.drop-element-attached-left.drop-target-attached-top .drop-content {
-    -moz-transform-origin: 0 calc(100% + 12px);
-    -ms-transform-origin: 0 calc(100% + 12px);
-    -webkit-transform-origin: 0 calc(100% + 12px);
-    transform-origin: 0 calc(100% + 12px); }
+    -webkit-transform-origin: 0, calc(100% + 12px);
+        -ms-transform-origin: 0, calc(100% + 12px);
+            transform-origin: 0, calc(100% + 12px); }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-bottom.drop-element-attached-right.drop-target-attached-top .drop-content {
-    -moz-transform-origin: 100% calc(100% + 12px);
-    -ms-transform-origin: 100% calc(100% + 12px);
-    -webkit-transform-origin: 100% calc(100% + 12px);
-    transform-origin: 100% calc(100% + 12px); }
+    -webkit-transform-origin: 100%, calc(100% + 12px);
+        -ms-transform-origin: 100%, calc(100% + 12px);
+            transform-origin: 100%, calc(100% + 12px); }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-top.drop-element-attached-right.drop-target-attached-left .drop-content {
-    -moz-transform-origin: calc(100% + 12px) 0;
-    -ms-transform-origin: calc(100% + 12px) 0;
-    -webkit-transform-origin: calc(100% + 12px) 0;
-    transform-origin: calc(100% + 12px) 0; }
+    -webkit-transform-origin: calc(100% + 12px), 0;
+        -ms-transform-origin: calc(100% + 12px), 0;
+            transform-origin: calc(100% + 12px), 0; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-top.drop-element-attached-left.drop-target-attached-right .drop-content {
-    -moz-transform-origin: -12px 0;
-    -ms-transform-origin: -12px 0;
-    -webkit-transform-origin: -12px 0;
-    transform-origin: -12px 0; }
+    -webkit-transform-origin: -12px, 0;
+        -ms-transform-origin: -12px, 0;
+            transform-origin: -12px, 0; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-bottom.drop-element-attached-right.drop-target-attached-left .drop-content {
-    -moz-transform-origin: calc(100% + 12px) 100%;
-    -ms-transform-origin: calc(100% + 12px) 100%;
-    -webkit-transform-origin: calc(100% + 12px) 100%;
-    transform-origin: calc(100% + 12px) 100%; }
+    -webkit-transform-origin: calc(100% + 12px), 100%;
+        -ms-transform-origin: calc(100% + 12px), 100%;
+            transform-origin: calc(100% + 12px), 100%; }
   .drop-element.drop-theme-arrows-bounce-dark.drop-element-attached-bottom.drop-element-attached-left.drop-target-attached-right .drop-content {
-    -moz-transform-origin: -12px 100%;
-    -ms-transform-origin: -12px 100%;
-    -webkit-transform-origin: -12px 100%;
-    transform-origin: -12px 100%; }
+    -webkit-transform-origin: -12px, 100%;
+        -ms-transform-origin: -12px, 100%;
+            transform-origin: -12px, 100%; }

--- a/dist/css/drop-theme-arrows-bounce.css
+++ b/dist/css/drop-theme-arrows-bounce.css
@@ -1,6 +1,4 @@
 .drop-element, .drop-element:after, .drop-element:before, .drop-element *, .drop-element *:after, .drop-element *:before {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box; }
 
 .drop-element {
@@ -13,8 +11,6 @@
   max-width: 100%;
   max-height: 100%; }
   .drop-element.drop-theme-arrows-bounce .drop-content {
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
     border-radius: 5px;
     position: relative;
     font-family: inherit;
@@ -23,12 +19,10 @@
     padding: 1em;
     font-size: 1.1em;
     line-height: 1.5em;
-    -moz-transform: translateZ(0);
-    -ms-transform: translateZ(0);
     -webkit-transform: translateZ(0);
-    transform: translateZ(0);
+            transform: translateZ(0);
     -webkit-filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2));
-    filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2)); }
+            filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2)); }
     .drop-element.drop-theme-arrows-bounce .drop-content:before {
       content: "";
       display: block;
@@ -116,96 +110,72 @@
       border-right-color: #fff; }
 
 .drop-element.drop-theme-arrows-bounce {
-  -moz-transform: translateZ(0);
-  -ms-transform: translateZ(0);
   -webkit-transform: translateZ(0);
-  transform: translateZ(0);
-  -moz-transition: opacity 0.1s;
-  -o-transition: opacity 0.1s;
-  -webkit-transition: opacity 0.1s;
-  transition: opacity 0.1s;
+          transform: translateZ(0);
+  -webkit-transition: opacity 100ms;
+          transition: opacity 100ms;
   opacity: 0; }
   .drop-element.drop-theme-arrows-bounce .drop-content {
-    -moz-transition: -moz-transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
-    -o-transition: -o-transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
     -webkit-transition: -webkit-transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
-    transition: transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
-    -moz-transform: scale(0) translateZ(0);
-    -ms-transform: scale(0) translateZ(0);
+            transition: transform 0.3s cubic-bezier(0, 0, 0.265, 1.55);
     -webkit-transform: scale(0) translateZ(0);
-    transform: scale(0) translateZ(0); }
+            transform: scale(0) translateZ(0); }
   .drop-element.drop-theme-arrows-bounce.drop-open {
     display: none; }
   .drop-element.drop-theme-arrows-bounce.drop-open-transitionend {
     display: block; }
   .drop-element.drop-theme-arrows-bounce.drop-after-open {
-    -moz-transition: none;
-    -o-transition: none;
     -webkit-transition: none;
-    transition: none;
+            transition: none;
     opacity: 1; }
     .drop-element.drop-theme-arrows-bounce.drop-after-open .drop-content {
-      -moz-transform: scale(1) translateZ(0);
-      -ms-transform: scale(1) translateZ(0);
       -webkit-transform: scale(1) translateZ(0);
-      transform: scale(1) translateZ(0); }
+              transform: scale(1) translateZ(0); }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-bottom.drop-element-attached-center .drop-content {
-    -moz-transform-origin: 50% calc(100% + 12px);
-    -ms-transform-origin: 50% calc(100% + 12px);
-    -webkit-transform-origin: 50% calc(100% + 12px);
-    transform-origin: 50% calc(100% + 12px); }
+    -webkit-transform-origin: 50%, calc(100% + 12px);
+        -ms-transform-origin: 50%, calc(100% + 12px);
+            transform-origin: 50%, calc(100% + 12px); }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-top.drop-element-attached-center .drop-content {
-    -moz-transform-origin: 50% -12px;
-    -ms-transform-origin: 50% -12px;
-    -webkit-transform-origin: 50% -12px;
-    transform-origin: 50% -12px; }
+    -webkit-transform-origin: 50%, -12px;
+        -ms-transform-origin: 50%, -12px;
+            transform-origin: 50%, -12px; }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-right.drop-element-attached-middle .drop-content {
-    -moz-transform-origin: calc(100% + 12px) 50%;
-    -ms-transform-origin: calc(100% + 12px) 50%;
-    -webkit-transform-origin: calc(100% + 12px) 50%;
-    transform-origin: calc(100% + 12px) 50%; }
+    -webkit-transform-origin: calc(100% + 12px), 50%;
+        -ms-transform-origin: calc(100% + 12px), 50%;
+            transform-origin: calc(100% + 12px), 50%; }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-left.drop-element-attached-middle .drop-content {
-    -moz-transform-origin: -12px 50%;
-    -ms-transform-origin: -12px 50%;
-    -webkit-transform-origin: -12px 50%;
-    transform-origin: -12px 50%; }
+    -webkit-transform-origin: -12px, 50%;
+        -ms-transform-origin: -12px, 50%;
+            transform-origin: -12px, 50%; }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-top.drop-element-attached-left.drop-target-attached-bottom .drop-content {
-    -moz-transform-origin: 0 -12px;
-    -ms-transform-origin: 0 -12px;
-    -webkit-transform-origin: 0 -12px;
-    transform-origin: 0 -12px; }
+    -webkit-transform-origin: 0, -12px;
+        -ms-transform-origin: 0, -12px;
+            transform-origin: 0, -12px; }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-top.drop-element-attached-right.drop-target-attached-bottom .drop-content {
-    -moz-transform-origin: 100% -12px;
-    -ms-transform-origin: 100% -12px;
-    -webkit-transform-origin: 100% -12px;
-    transform-origin: 100% -12px; }
+    -webkit-transform-origin: 100%, -12px;
+        -ms-transform-origin: 100%, -12px;
+            transform-origin: 100%, -12px; }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-bottom.drop-element-attached-left.drop-target-attached-top .drop-content {
-    -moz-transform-origin: 0 calc(100% + 12px);
-    -ms-transform-origin: 0 calc(100% + 12px);
-    -webkit-transform-origin: 0 calc(100% + 12px);
-    transform-origin: 0 calc(100% + 12px); }
+    -webkit-transform-origin: 0, calc(100% + 12px);
+        -ms-transform-origin: 0, calc(100% + 12px);
+            transform-origin: 0, calc(100% + 12px); }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-bottom.drop-element-attached-right.drop-target-attached-top .drop-content {
-    -moz-transform-origin: 100% calc(100% + 12px);
-    -ms-transform-origin: 100% calc(100% + 12px);
-    -webkit-transform-origin: 100% calc(100% + 12px);
-    transform-origin: 100% calc(100% + 12px); }
+    -webkit-transform-origin: 100%, calc(100% + 12px);
+        -ms-transform-origin: 100%, calc(100% + 12px);
+            transform-origin: 100%, calc(100% + 12px); }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-top.drop-element-attached-right.drop-target-attached-left .drop-content {
-    -moz-transform-origin: calc(100% + 12px) 0;
-    -ms-transform-origin: calc(100% + 12px) 0;
-    -webkit-transform-origin: calc(100% + 12px) 0;
-    transform-origin: calc(100% + 12px) 0; }
+    -webkit-transform-origin: calc(100% + 12px), 0;
+        -ms-transform-origin: calc(100% + 12px), 0;
+            transform-origin: calc(100% + 12px), 0; }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-top.drop-element-attached-left.drop-target-attached-right .drop-content {
-    -moz-transform-origin: -12px 0;
-    -ms-transform-origin: -12px 0;
-    -webkit-transform-origin: -12px 0;
-    transform-origin: -12px 0; }
+    -webkit-transform-origin: -12px, 0;
+        -ms-transform-origin: -12px, 0;
+            transform-origin: -12px, 0; }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-bottom.drop-element-attached-right.drop-target-attached-left .drop-content {
-    -moz-transform-origin: calc(100% + 12px) 100%;
-    -ms-transform-origin: calc(100% + 12px) 100%;
-    -webkit-transform-origin: calc(100% + 12px) 100%;
-    transform-origin: calc(100% + 12px) 100%; }
+    -webkit-transform-origin: calc(100% + 12px), 100%;
+        -ms-transform-origin: calc(100% + 12px), 100%;
+            transform-origin: calc(100% + 12px), 100%; }
   .drop-element.drop-theme-arrows-bounce.drop-element-attached-bottom.drop-element-attached-left.drop-target-attached-right .drop-content {
-    -moz-transform-origin: -12px 100%;
-    -ms-transform-origin: -12px 100%;
-    -webkit-transform-origin: -12px 100%;
-    transform-origin: -12px 100%; }
+    -webkit-transform-origin: -12px, 100%;
+        -ms-transform-origin: -12px, 100%;
+            transform-origin: -12px, 100%; }

--- a/dist/css/drop-theme-arrows.css
+++ b/dist/css/drop-theme-arrows.css
@@ -1,6 +1,4 @@
 .drop-element, .drop-element:after, .drop-element:before, .drop-element *, .drop-element *:after, .drop-element *:before {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box; }
 
 .drop-element {
@@ -13,8 +11,6 @@
   max-width: 100%;
   max-height: 100%; }
   .drop-element.drop-theme-arrows .drop-content {
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
     border-radius: 5px;
     position: relative;
     font-family: inherit;
@@ -23,12 +19,10 @@
     padding: 1em;
     font-size: 1.1em;
     line-height: 1.5em;
-    -moz-transform: translateZ(0);
-    -ms-transform: translateZ(0);
     -webkit-transform: translateZ(0);
-    transform: translateZ(0);
+            transform: translateZ(0);
     -webkit-filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2));
-    filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2)); }
+            filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2)); }
     .drop-element.drop-theme-arrows .drop-content:before {
       content: "";
       display: block;

--- a/dist/css/drop-theme-basic.css
+++ b/dist/css/drop-theme-basic.css
@@ -1,6 +1,4 @@
 .drop-element, .drop-element:after, .drop-element:before, .drop-element *, .drop-element *:after, .drop-element *:before {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box; }
 
 .drop-element {
@@ -13,11 +11,7 @@
   max-width: 100%;
   max-height: 100%; }
   .drop-element.drop-theme-basic .drop-content {
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
     border-radius: 5px;
-    -moz-box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-    -webkit-box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     font-family: inherit;
     background: #eee;

--- a/dist/css/drop-theme-hubspot-popovers.css
+++ b/dist/css/drop-theme-hubspot-popovers.css
@@ -1,6 +1,4 @@
 .drop-element, .drop-element:after, .drop-element:before, .drop-element *, .drop-element *:after, .drop-element *:before {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box; }
 
 .drop-element {
@@ -13,8 +11,6 @@
   max-width: 100%;
   max-height: 100%; }
   .drop-element.drop-theme-hubspot-popovers .drop-content {
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
     border-radius: 5px;
     position: relative;
     font-family: inherit;
@@ -110,11 +106,7 @@
       border-right-color: #ebebeb; }
 
 .drop-element.drop-theme-hubspot-popovers .drop-content {
-  -moz-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.2);
-  -webkit-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.2);
   box-shadow: 0 3px 7px rgba(0, 0, 0, 0.2);
-  -moz-border-radius: 2px;
-  -webkit-border-radius: 2px;
   border-radius: 2px;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   padding: 3px;

--- a/dist/js/drop.js
+++ b/dist/js/drop.js
@@ -1,4 +1,4 @@
-/*! tether-drop 1.0.2 */
+/*! tether-drop 1.0.3 */
 
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,13 +3,13 @@ var gulp        = require('gulp');
 var babel       = require('gulp-babel');
 var bump        = require('gulp-bump');
 var filter      = require('gulp-filter');
-var sass        = require('gulp-ruby-sass');
 var header      = require('gulp-header');
+var prefixer    = require('gulp-autoprefixer');
 var rename      = require('gulp-rename');
 var uglify      = require('gulp-uglify');
+var sass        = require('gulp-sass');
 var tagVersion  = require('gulp-tag-version');
 var umd         = require('gulp-wrap-umd');
-
 
 // Variables
 var distDir = './dist';
@@ -53,11 +53,12 @@ gulp.task('js', ['clean'], function() {
 
 // CSS
 gulp.task('css', function() {
-  sass('./src/css', {
-    loadPath: './bower_components',
-    compass: true
-  })
-  .pipe(gulp.dest(distDir + '/css'));
+  gulp.src('./src/css/**/*.sass')
+    .pipe(sass({
+      includePaths: ['./bower_components']
+    }))
+    .pipe(prefixer())
+    .pipe(gulp.dest(distDir + '/css'));
 });
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tether-drop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "authors": [
     "Zack Bloom <zackbloom@gmail.com>",
@@ -30,6 +30,6 @@
     "gulp-wrap-umd": "^0.2.1"
   },
   "dependencies": {
-    "tether": "^0.7.1"
+    "tether": "^0.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
   "devDependencies": {
     "del": "^1.1.1",
     "gulp": "^3.8.11",
+    "gulp-autoprefixer": "^2.2.0",
     "gulp-babel": "^5.1.0",
     "gulp-bump": "^0.3.0",
     "gulp-filter": "^2.0.2",
     "gulp-header": "^1.2.2",
     "gulp-rename": "^1.2.2",
-    "gulp-ruby-sass": "^1.0.5",
+    "gulp-sass": "^2.0.0",
     "gulp-tag-version": "^1.2.1",
     "gulp-uglify": "^1.2.0",
     "gulp-wrap-umd": "^0.2.1"

--- a/src/css/drop-theme-arrows-bounce-dark.sass
+++ b/src/css/drop-theme-arrows-bounce-dark.sass
@@ -1,5 +1,3 @@
-@import ../bower_components/tether/sass/mixins/pointer-events
-
 @import ../bower_components/tether/sass/helpers/tether
 @import ../bower_components/tether/sass/helpers/tether-theme-arrows
 

--- a/src/css/drop-theme-arrows-bounce-dark.sass
+++ b/src/css/drop-theme-arrows-bounce-dark.sass
@@ -1,6 +1,3 @@
-@import compass/css3
-@import compass/utilities/general/clearfix
-
 @import ../bower_components/tether/sass/mixins/pointer-events
 
 @import ../bower_components/tether/sass/helpers/tether

--- a/src/css/drop-theme-arrows-bounce.sass
+++ b/src/css/drop-theme-arrows-bounce.sass
@@ -1,5 +1,3 @@
-@import ../bower_components/tether/sass/mixins/pointer-events
-
 @import ../bower_components/tether/sass/helpers/tether
 @import ../bower_components/tether/sass/helpers/tether-theme-arrows
 

--- a/src/css/drop-theme-arrows-bounce.sass
+++ b/src/css/drop-theme-arrows-bounce.sass
@@ -1,6 +1,3 @@
-@import compass/css3
-@import compass/utilities/general/clearfix
-
 @import ../bower_components/tether/sass/mixins/pointer-events
 
 @import ../bower_components/tether/sass/helpers/tether

--- a/src/css/drop-theme-arrows.sass
+++ b/src/css/drop-theme-arrows.sass
@@ -1,5 +1,3 @@
-@import ../bower_components/tether/sass/mixins/pointer-events
-
 @import ../bower_components/tether/sass/helpers/tether
 @import ../bower_components/tether/sass/helpers/tether-theme-arrows
 

--- a/src/css/drop-theme-arrows.sass
+++ b/src/css/drop-theme-arrows.sass
@@ -1,6 +1,3 @@
-@import compass/css3
-@import compass/utilities/general/clearfix
-
 @import ../bower_components/tether/sass/mixins/pointer-events
 
 @import ../bower_components/tether/sass/helpers/tether

--- a/src/css/drop-theme-basic.sass
+++ b/src/css/drop-theme-basic.sass
@@ -1,6 +1,3 @@
-@import compass/css3
-@import compass/utilities/general/clearfix
-
 @import ../bower_components/tether/sass/helpers/tether
 @import ../bower_components/tether/sass/helpers/tether-theme-basic
 

--- a/src/css/drop-theme-hubspot-popovers.sass
+++ b/src/css/drop-theme-hubspot-popovers.sass
@@ -1,6 +1,3 @@
-@import compass/css3
-@import compass/utilities/general/clearfix
-
 @import ../bower_components/tether/sass/mixins/pointer-events
 
 @import ../bower_components/tether/sass/helpers/tether
@@ -19,8 +16,8 @@ $useDropShadow: false
 .drop-element.drop-theme-hubspot-popovers
 
     .drop-content
-        +box-shadow(0 3px 7px rgba(0, 0, 0, .2))
-        +border-radius(2px)
+        box-shadow: 0 3px 7px rgba(0, 0, 0, .2)
+        border-radius: 2px
         font-family: "Helvetica Neue", Helvetica, Arial, sans-serif
         //border: 1px solid #b3b3b3
         padding: 3px

--- a/src/css/drop-theme-hubspot-popovers.sass
+++ b/src/css/drop-theme-hubspot-popovers.sass
@@ -1,5 +1,3 @@
-@import ../bower_components/tether/sass/mixins/pointer-events
-
 @import ../bower_components/tether/sass/helpers/tether
 @import ../bower_components/tether/sass/helpers/tether-theme-arrows
 

--- a/src/css/helpers/_drop-animation-scale.sass
+++ b/src/css/helpers/_drop-animation-scale.sass
@@ -1,14 +1,12 @@
-@import compass/css3
-
 =drop-animation-scale($themePrefix: "drop", $themeName: "default", $attachmentOffset: 0, $easing: "linear")
     .#{ $themePrefix }-element.#{ $themePrefix }-theme-#{ $themeName }
-        +transform(translateZ(0))
-        +transition(opacity .1s)
+        transform: translateZ(0)
+        transition: opacity 100ms
         opacity: 0
 
         .#{ $themePrefix }-content
-            +transition(transform .3s $easing)
-            +transform(scale(0) translateZ(0))
+            transition: transform .3s $easing
+            transform: scale(0) translateZ(0)
 
         &.#{ $themePrefix }-open
             display: none
@@ -17,50 +15,50 @@
             display: block
 
         &.#{ $themePrefix }-after-open
-            +transition(none)
+            transition: none
             opacity: 1
 
             .#{ $themePrefix }-content
-                +transform(scale(1) translateZ(0))
+                transform: scale(1) translateZ(0)
 
         // Centers and middles
 
         &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-center .#{ $themePrefix }-content
-            +transform-origin(50%, #{ "calc(100% + " }#{ $attachmentOffset }#{ ")"})
+            transform-origin: 50%, #{ "calc(100% + " }#{ $attachmentOffset }#{ ")"}
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-center .#{ $themePrefix }-content
-            +transform-origin(50%, -$attachmentOffset)
+            transform-origin: 50%, -$attachmentOffset
 
         &.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-element-attached-middle .#{ $themePrefix }-content
-            +transform-origin(#{ "calc(100% + " }#{ $attachmentOffset }#{ ")"}, 50%)
+            transform-origin: #{ "calc(100% + " }#{ $attachmentOffset }#{ ")"}, 50%
 
         &.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-element-attached-middle .#{ $themePrefix }-content
-            +transform-origin(-$attachmentOffset, 50%)
+            transform-origin: -$attachmentOffset, 50%
 
         // Top and bottom corners
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-target-attached-bottom .#{ $themePrefix }-content
-            +transform-origin(0, -$attachmentOffset)
+            transform-origin: 0, -$attachmentOffset
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-target-attached-bottom .#{ $themePrefix }-content
-            +transform-origin(100%, -$attachmentOffset)
+            transform-origin: 100%, -$attachmentOffset
 
         &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-target-attached-top .#{ $themePrefix }-content
-            +transform-origin(0, #{ "calc(100% + " }#{ $attachmentOffset }#{ ")"})
+            transform-origin: 0, #{ "calc(100% + " }#{ $attachmentOffset }#{ ")"}
 
         &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-target-attached-top .#{ $themePrefix }-content
-            +transform-origin(100%, #{ "calc(100% + " }#{ $attachmentOffset }#{ ")"})
+            transform-origin: 100%, #{ "calc(100% + " }#{ $attachmentOffset }#{ ")"}
 
         // Side corners
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-target-attached-left .#{ $themePrefix }-content
-            +transform-origin(#{ "calc(100% + " }#{ $attachmentOffset }#{ ")"}, 0)
+            transform-origin: #{ "calc(100% + " }#{ $attachmentOffset }#{ ")"}, 0
 
         &.#{ $themePrefix }-element-attached-top.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-target-attached-right .#{ $themePrefix }-content
-            +transform-origin(-$attachmentOffset, 0)
+            transform-origin: -$attachmentOffset, 0
 
         &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-right.#{ $themePrefix }-target-attached-left .#{ $themePrefix }-content
-            +transform-origin(#{ "calc(100% + " }#{ $attachmentOffset }#{ ")"}, 100%)
+            transform-origin: #{ "calc(100% + " }#{ $attachmentOffset }#{ ")"}, 100%
 
         &.#{ $themePrefix }-element-attached-bottom.#{ $themePrefix }-element-attached-left.#{ $themePrefix }-target-attached-right .#{ $themePrefix }-content
-            +transform-origin(-$attachmentOffset, 100%)
+            transform-origin: -$attachmentOffset, 100%


### PR DESCRIPTION
__[Progress]__: Ready to merge. Sanity checking.

Removes Compass + Ruby dependencies by replacing `gulp-compass` with `gulp-autoprefixer` and `gulp-sass`. Nothing really needed `compass`, so remove the extra, fairly bloated dependency making it harder to comtribute if Ruby + Compass are not installed.

Depends on https://github.com/HubSpot/tether/pull/82