### PR TITLE
Check for drop to prevent race conditions

### DIFF
--- a/src/js/drop.js
+++ b/src/js/drop.js
@@ -370,6 +370,11 @@ function createContext(options={}) {
       if (this.isOpened()) {
         return;
       }
+      
+      if (!this.drop) {
+        // The instance was destroyed
+        return;
+      }
 
       if (!this.drop.parentNode) {
         document.body.appendChild(this.drop);


### PR DESCRIPTION
The `inHandler` uses `setTimeout()` function to schedule `this.open()` call. If client calls `drop.destroy()` before timeout is triggered, the instance of `this.drop` will be set to `null` which results in unhandled error in `open()`

This change fixes the unhandled error.