### PR TITLE
http -> https (Removes console errors from site)

### DIFF
--- a/docs/welcome/index.html
+++ b/docs/welcome/index.html
@@ -5,7 +5,7 @@
     <title>Drop</title>
     <meta name="description" content="Drop is a JavaScript and CSS library. It is free and open source and was developed by HubSpot developers Adam Schwartz (@adamfschwartz) and Zack Bloom (@zackbloom).">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-    <link rel="icon" href="http://static.hubspot.com/favicon.ico">
+    <link rel="icon" href="https://static.hubspot.com/favicon.ico">
 
     <script type="text/javascript" src="//use.typekit.net/jbn8qxr.js"></script>
     <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
@@ -118,11 +118,11 @@
                     <!--
                     <div class="example">
                         <h2>The Context Menu</h2>
-                        <div class="example-inner">http://www.lexus-int.com/news/</div>
+                        <div class="example-inner">https://www.lexus-int.com/news/</div>
                     </div>
                     <div class="example">
                         <h2>Fold Down</h2>
-                        <div class="example-inner">http://www.lexus-int.com/news/</div>
+                        <div class="example-inner">https://www.lexus-int.com/news/</div>
                     </div>
                     -->
                 </div>
@@ -166,7 +166,7 @@
             </style>
             <div class="share-buttons">
                 <div class="share-button retweet-button">
-                    <a href="http://twitter.com/share" class="twitter-share-button" data-url="http://github.hubspot.com/drop/docs/welcome" data-text="Tether.js - Marrying elements for life" data-count="horizontal" data-via="HubSpotDev">Tweet</a>
+                    <a href="https://twitter.com/share" class="twitter-share-button" data-url="https://github.hubspot.com/drop/docs/welcome" data-text="Tether.js - Marrying elements for life" data-count="horizontal" data-via="HubSpotDev">Tweet</a>
                     <script>
                         (function(){
                             var recommends, button;
@@ -184,10 +184,10 @@
                             }
                         })();
                     </script>
-                    <script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
+                    <script type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>
                 </div>
                 <div class="share-button github-stars-button">
-                    <iframe src="http://ghbtns.com/github-btn.html?user=HubSpot&amp;repo=drop&amp;type=watch&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="100" height="20"></iframe>
+                    <iframe src="https://ghbtns.com/github-btn.html?user=HubSpot&amp;repo=drop&amp;type=watch&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="100" height="20"></iframe>
                 </div>
             </p>
         </div>


### PR DESCRIPTION
The developer console gets flooded with errors when viewing https://github.hubspot.com/drop/docs/welcome/ due to the resources being loaded over HTTPS by default despite the code saying to load them over HTTP. 

All links were tested and changed to HTTPS.

![chrome_L3ZmnP1AVt](https://user-images.githubusercontent.com/19174130/92844037-52299400-f3dd-11ea-827e-12f7991774ff.png)